### PR TITLE
プロフィール編集欄のデザイン修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import ArtPage from "pages/art";
 const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
-    font-family: YuGo, 'Noto Sans JP', sans-serif, Robot-Light,;
+    font-family: YuGo, 'Noto Sans JP', sans-serif, Robot-Light;
   }
   * {
     box-sizing: border-box;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import ArtPage from "pages/art";
 const GlobalStyle = createGlobalStyle`
   body {
     margin: 0;
-    font-family: Robot-Light;
+    font-family: YuGo, 'Noto Sans JP', sans-serif, Robot-Light,;
   }
   * {
     box-sizing: border-box;

--- a/src/components/select_image.tsx
+++ b/src/components/select_image.tsx
@@ -25,7 +25,7 @@ export default ({ image, setImage }: Props) => {
   return (
     <Container>
       <Sumbnail image={image} />
-      <SelectImageRect>Select</SelectImageRect>
+      <SelectImageRect>プロフィール写真を変更する</SelectImageRect>
       <HiddenFileInput
         type="file"
         accept="image/*"
@@ -49,17 +49,20 @@ const Container = styled.label`
 
 const SelectImageRect = styled.div`
   position: absolute;
-  left: 10px;
+  right: 0;
   bottom: 10px;
-  width: 60px;
+  width: 100%;
   height: 30px;
-  background-color: black;
-  color: white;
+  color: #333;
   border-radius: 4px;
-  text-align: center;
-  font-size: 13px;
-  font-weight: bold;
-  line-height: 30px;
+  text-align: right;
+  font-size: 12px;
+  letter-spacing: 0.46px;
+  ${pc(`
+    bottom: 0px;
+    left: 0;
+    text-align: left;
+  `)}
 `;
 
 const HiddenFileInput = styled.input`

--- a/src/pages/settings/components/tab.tsx
+++ b/src/pages/settings/components/tab.tsx
@@ -2,6 +2,8 @@ import React, {FC} from 'react';
 import styled from 'styled-components';
 import {Link} from 'react-router-dom';
 
+import { pc } from "components/responsive";
+
 interface Props {
   selected: 'tab1' | 'tab2';
 }
@@ -36,18 +38,24 @@ const TabItem: FC<{selected: boolean; to: string}> = ({
 const Container = styled.div`
   width: 100%;
   height: 55px;
-  background-color: #fafbfc;
+  background-color: #fafafa;
   border-bottom: 1px solid #e1e4e8;
 `;
 
 const TabItemBase = styled(Link)`
   display: inline-block;
   width: 50%;
-  height: 50px;
-  margin-top: 5px;
+  height: 55px;
+  font-size: 14px;
   text-align: center;
-  line-height: 50px;
+  line-height: 55px;
+  letter-spacing: 1.37px;
+  text-decoration: none;
   border-radius: 4px 4px 0px 0px;
+
+  ${pc(`
+    font-size: 16px;
+  `)}
 `;
 
 const SelectedTab = styled(TabItemBase)`

--- a/src/pages/settings/profile.tsx
+++ b/src/pages/settings/profile.tsx
@@ -48,7 +48,7 @@ const ProfileSettingPage: React.FC<UserProps> = ({ user }) => {
       <SettingTab selected="tab1" />
       <Container>
         <LinkToArtistPage to={`/${artist.uid}`}>
-          自分の作家ページを確認する →
+          自分の作家ページをプレビューする →
         </LinkToArtistPage>
         <SelectImageComponent
           image={thumbnail || ArtistDefaultThumbnail}
@@ -58,7 +58,7 @@ const ProfileSettingPage: React.FC<UserProps> = ({ user }) => {
         {updating ? (
           <UpdateButton disabled>Updating...</UpdateButton>
         ) : (
-          <UpdateButton onClick={onSubmit}>Update</UpdateButton>
+          <UpdateButton onClick={onSubmit}>プロフィールを更新する</UpdateButton>
         )}
       </Container>
       <Footer />
@@ -73,9 +73,10 @@ const ArtistDefaultThumbnail = DownloadImage.download(
 );
 
 const Container = styled.div`
-  width: 80%;
+  width: 86%;
   margin: 0px auto;
   padding: 50px 0;
+  font-family: YuGo, 'Noto Sans JP';
 
   ${pc(`
     margin-top: 90px;
@@ -85,15 +86,32 @@ const Container = styled.div`
 const LinkToArtistPage = styled(Link)`
   display: block;
   margin-bottom: 20px;
+  font-size: 12px;
+  line-height: 1.45;
+  letter-spacing: 0.46px;
   text-decoration: underline;
-  color: #586069;
+  text-align: right;
+  color: #333333;
 
   &:visited {
     color: #586069;
   }
+
+  ${pc(`
+    font-size: 16px;
+    text-align: left;
+  `)}
 `;
 
-const UpdateButton = styled(PrimaryButton)`
+const UpdateButton = styled.button`
   display: block;
+  width: 100%;
+  height: 51px;
   margin: 30px auto 0 auto;
+  background: white;
+  border-radius: 2px;
+  border: solid 1.5px #666666;
+  font-size: 13px;
+  letter-spacing: 1.18px;
+  color: #333333;
 `;

--- a/src/pages/settings/profile/components/edit_attributes.tsx
+++ b/src/pages/settings/profile/components/edit_attributes.tsx
@@ -12,7 +12,7 @@ const EditAttributesComponent: React.FC<Props> = ({ attrs, setAttrs }) => {
   return (
     <Container>
       <EditAttributeElement>
-        <AttributeName>Name</AttributeName>
+        <AttributeName>名前 / Name</AttributeName>
         <InputField
           type="text"
           value={attrs.name}
@@ -20,7 +20,7 @@ const EditAttributesComponent: React.FC<Props> = ({ attrs, setAttrs }) => {
         />
       </EditAttributeElement>
       <EditAttributeElement>
-        <AttributeName>Status Message</AttributeName>
+        <AttributeName>ヒトコト / Status Message</AttributeName>
         <InputField
           type="text"
           value={attrs.comment}
@@ -28,7 +28,7 @@ const EditAttributesComponent: React.FC<Props> = ({ attrs, setAttrs }) => {
         />
       </EditAttributeElement>
       <EditAttributeElement>
-        <AttributeName>Profile</AttributeName>
+        <AttributeName>プロフィール / Profile</AttributeName>
         <TextField
           value={attrs.description}
           onChange={e => setAttrs({ ...attrs, description: e.target.value })}
@@ -71,6 +71,7 @@ export default EditAttributesComponent;
 const Container = styled.div`
   width: 100%;
   padding: 30px 0;
+  font-family: YuGo, sans-serif;
 `;
 
 const EditAttributeElement = styled.div`
@@ -83,9 +84,10 @@ const EditAttributeElement = styled.div`
 `;
 
 const AttributeName = styled.div`
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  margin-bottom: 5px;
+  margin-bottom: 8px;
+  color: #333333;
 `;
 
 const InputField = styled.input`
@@ -93,23 +95,23 @@ const InputField = styled.input`
   height: 34px;
   margin-right: 5px;
   padding: 6px 8px;
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
-  border-radius: 3px;
-  box-shadow: inset 0 1px 2px rgba(27, 31, 35, 0.075);
+  border: 0;
+  border-radius: 0;
+  border-bottom: 1px solid #acacac;
   font-size: 14px;
   line-height: 20px;
+  color: #acacac;
 `;
 
 const TextField = styled.textarea`
   width: 100%;
-  height: 74px;
+  height: 162px;
   margin-right: 5px;
   padding: 6px 8px;
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
-  border-radius: 3px;
-  box-shadow: inset 0 1px 2px rgba(27, 31, 35, 0.075);
-  font-size: 14px;
+  background-color: white;
+  border: 1px solid #acacac;
+  border-radius: 2px;
+  font-size: 12px;
   line-height: 20px;
+  color: #acacac;
 `;


### PR DESCRIPTION
@AtsukiTak review me
[参考デザイン](https://zpl.io/agj4D69)

※自分の作家ページをプレビューする〜プロフィール写真を変更するの間は画像が入る

モバイル
<img width="364" alt="スクリーンショット 2020-10-04 20 21 02" src="https://user-images.githubusercontent.com/33197316/95014043-371a0f00-067f-11eb-9ac1-23fcec9592ca.png">
<img width="365" alt="スクリーンショット 2020-10-04 20 21 08" src="https://user-images.githubusercontent.com/33197316/95014047-397c6900-067f-11eb-9790-cb77e54c9521.png">
<img width="366" alt="スクリーンショット 2020-10-04 20 21 15" src="https://user-images.githubusercontent.com/33197316/95014048-3aad9600-067f-11eb-94a4-cc2d71bc5fad.png">

PC

<img width="1281" alt="スクリーンショット 2020-10-04 20 22 55" src="https://user-images.githubusercontent.com/33197316/95014084-72b4d900-067f-11eb-89eb-4f0eb7f2ad2b.png">
<img width="1277" alt="スクリーンショット 2020-10-04 20 23 03" src="https://user-images.githubusercontent.com/33197316/95014085-73e60600-067f-11eb-9ba5-3971c8322155.png">
