### PR TITLE
作品一覧ページのデザイン修正

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -30,11 +30,14 @@ const Container = styled.footer`
 
 const HR = styled.hr`
   width: 10%;
+  height: 1px;
   margin-top: 65px;
   margin-bottom: 65px;
-  border: 0.5px solid #979797;
+  background: #c9c9c9;;
+  border: 0;
 
   ${pc(`
+    width: 5%;
     margin-top: 130px;
     margin-bottom: 100px;
   `)}

--- a/src/pages/settings/arts/components/arts.tsx
+++ b/src/pages/settings/arts/components/arts.tsx
@@ -16,9 +16,8 @@ const ArtsComponent: FC<Props> = ({ arts }) => {
     <Container>
       <ArtContainer key="new">
         <Link to={`/settings/arts/add`}>
-          <Sumbnail image={DefaultArtThumbnail} />
+          <AddArtButton>作品を追加する</AddArtButton>
         </Link>
-        <ArtTitle>作品を追加する</ArtTitle>
       </ArtContainer>
       {arts.map(art => (
         <ArtContainer key={art.id}>
@@ -41,6 +40,7 @@ export default ArtsComponent;
 const Container = styled.div`
   width: 100%;
   padding-bottom: 50px;
+  font-family: YuGo, sans-serif;
 
   ${pc(`
     justify-content: start;
@@ -50,17 +50,40 @@ const Container = styled.div`
 
 const ArtContainer = styled.div`
   display: block;
-  width: 50vw;
+  width: 80vw;
   margin: 50px auto 0 auto;
 
+  & a {
+    text-decoration: none;
+  }
+
   ${pc(`
-    width: 280px;
-    margin: 25px 70px;
+    margin: 50px auto;
   `)}
 `;
 
-const ArtTitle = styled.h4`
+const ArtTitle = styled.p`
   margin: 0;
   margin-top: 5px;
-  color: gray;
+  text-align: center;
+  font-size: 12px;
+  letter-spacing: 1.2px;
+  line-height: 2;
+  color: #333333;
+  font-family: YuGo, sans-serif;
+`;
+
+
+const AddArtButton = styled.button`
+  display: block;
+  width: 100%;
+  height: 51px;
+  margin: 30px auto 0 auto;
+  background: white;
+  border-radius: 2px;
+  border: solid 1.5px #666666;
+  font-size: 13px;
+  letter-spacing: 1.18px;
+  color: #333333;
+  font-family: YuGo, sans-serif;
 `;


### PR DESCRIPTION
@AtsukiTak review me
- 作品追加するデフォルトイメージの削除
- 作品を追加するをボタンに変更
- 横の余白を少なく
- 作品タイトルをセンタリング
- footerの区切り線を細くする

<img width="1277" alt="スクリーンショット 2020-10-06 10 29 35" src="https://user-images.githubusercontent.com/33197316/95148684-e3164400-07be-11eb-99bd-b81605f9c201.png">

<img width="360" alt="スクリーンショット 2020-10-06 10 28 27" src="https://user-images.githubusercontent.com/33197316/95148680-e1e51700-07be-11eb-9899-c729e7518225.png">
