### PR TITLE
作品個別ページ遷移時に、スクロールトップから始まる修正

### DIFF
--- a/src/hooks/scrollToTop.ts
+++ b/src/hooks/scrollToTop.ts
@@ -1,0 +1,7 @@
+import React from "react";
+
+export const useScrollToTop = (): void => {
+  React.useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+};

--- a/src/pages/art.tsx
+++ b/src/pages/art.tsx
@@ -12,6 +12,7 @@ import { Artist, buyArt } from "models/artist";
 import { Art } from "models/art";
 import { RootState } from "services/index";
 import { getArtistById } from "services/artist";
+import { useScrollToTop } from "hooks/scrollToTop";
 import { pc } from "components/responsive";
 
 import * as color from "components/color";
@@ -26,6 +27,8 @@ const ArtPage: FC<ArtPageProps> = ({ artistId, artId }) => {
     state.artist.map.get(artistId)
   );
   const dispatch = useDispatch();
+
+  useScrollToTop();
 
   useEffect(() => {
     if (artistArts === undefined) {


### PR DESCRIPTION
@AtsukiTak review me

- `hooks/scrollToTop.ts`の追加
- 作品個別ページに適用