### PR TITLE
wip:menuの追加、フッターメニューの削除

### DIFF
--- a/src/components/close.svg
+++ b/src/components/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>

--- a/src/components/color.ts
+++ b/src/components/color.ts
@@ -37,5 +37,6 @@ function fromHex(hex: string): number {
 export const White = Color.fromHex("#ffffff");
 export const Black = Color.fromHex("#000000");
 export const LightBlack = Color.fromHex("#333333");
+export const LightBlack4 = Color.fromHex("#444444");
 export const MidGray = Color.fromHex("#666666");
 export const LightGray = Color.fromHex("#a1a1a1");

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,94 +2,19 @@ import React from "react";
 import styled from "styled-components";
 import * as color from "./color";
 
-import { pc } from "components/responsive";
-
 const Footer = () => {
-  return (
-    <Container>
-      <HR />
-      <FooterList>
-        <FooterListItem>
-          <Link href="/terms.pdf" target="_blank">
-            利用規約
-          </Link>
-        </FooterListItem>
-        <FooterListItem>
-          <Link href="/privacy-policy.pdf" target="_blank">
-            プライバシーポリシー
-          </Link>
-        </FooterListItem>
-        <FooterListItem>
-          <Link
-            href="/specified-commercial-transaction-act.pdf"
-            target="_blank"
-          >
-            特定商取引法に基づく表示
-          </Link>
-        </FooterListItem>
-      </FooterList>
-      <CopyRight>©ARTELL, Inc.</CopyRight>
-    </Container>
-  );
+  return <Container>For Art People, Always.</Container>;
 };
 
 export default Footer;
 
 const Container = styled.footer`
   width: 100vw;
-  height: 60px;
-  line-height: 60px;
-  margin-top: 140px;
+  margin: 32px auto;
   text-align: center;
-`;
-
-const HR = styled.hr`
-  width: 10%;
-  height: 1px;
-  margin-top: 65px;
-  margin-bottom: 65px;
-  background: #c9c9c9;
-  border: 0;
-
-  ${pc(`
-    width: 5%;
-    margin-top: 130px;
-    margin-bottom: 100px;
-  `)}
-`;
-
-const FooterList = styled.ul`
-  list-style: none;
-  padding: 0;
-`;
-
-const FooterListItem = styled.li`
-  margin-bottom: 12px;
-  font-size: 14px;
-  letter-spacing: 1.6px;
-  &:last-child {
-    margin-bottom: 65px;
-  }
-
-  ${pc(`
-    left: 100px;
-    font-size: 16px;
-  `)}
-`;
-
-const Link = styled.a`
-  text-decoration: none;
-  color: ${color.LightBlack.hex};
-`;
-
-const CopyRight = styled.div`
-  font-size: 12px;
+  font-family: AvenirNext-MediumItalic;
+  font-size: 10px;
   letter-spacing: 1.6px;
   text-decoration: none;
-  color: ${color.LightBlack.hex};
-
-  ${pc(`
-    left: 100px;
-    font-size: 12px;
-  `)}
+  color: ${color.LightGray.hex};
 `;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,19 +3,19 @@ import styled from "styled-components";
 import { Link } from "react-router-dom";
 
 import * as color from "./color";
-import { ArtellInstagram } from "./logo";
+import { ReactComponent as LogoMenuIcon } from "./nav-menu.svg";
+import Menu from "components/menu";
 
 const Header: FC = () => {
+  const [isOpenMenuModal, setIsOpenMenuModal] = React.useState<boolean>(false);
+  const closeMenuModal = () => setIsOpenMenuModal(false);
+
   return (
     <Container>
       <FlexBox>
         <Title to="/">PORTFOLIO</Title>
-        <SnsLink
-          href="https://www.instagram.com/artell_gallery/"
-          target="_blank"
-        >
-          <ArtellInstagram />
-        </SnsLink>
+        <IconMenu onClick={() => setIsOpenMenuModal(!isOpenMenuModal)} />
+        {isOpenMenuModal ? <Menu onCloseMenuModal={closeMenuModal} /> : null}
       </FlexBox>
     </Container>
   );
@@ -30,11 +30,15 @@ const Container = styled.header`
   @media (min-width: 700px) {
     font-size: 24px;
   }
+  & body {
+    overflow: hidden;
+  }
 `;
 
 const FlexBox = styled.div`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
 
 const Title = styled(Link)`
@@ -51,9 +55,9 @@ const Title = styled(Link)`
   }
 `;
 
-const SnsLink = styled.a`
-  & svg {
-    width: 20px;
-    height: 20px;
-  }
+const IconMenu = styled(LogoMenuIcon)`
+  width: 24px;
+  height: 24px;
+  margin-bottom: 2px;
+  fill: ${color.LightBlack4.hex};
 `;

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,0 +1,136 @@
+import React, { FC } from "react";
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+import { pc } from "components/responsive";
+
+import * as color from "./color";
+import { ReactComponent as LogoCloseIcon } from "./close.svg";
+
+interface Props {
+  onCloseMenuModal: () => void;
+}
+
+const Menu: FC<Props> = ({ onCloseMenuModal }) => {
+  return (
+    <Container>
+      <CloseIcon onClick={() => onCloseMenuModal()} />
+      <Section>
+        <Tag>For Users</Tag>
+        <Item to="/">アーティスト会員登録</Item>
+        <Item to="/signin">ログイン</Item>
+        {/* <Item to="/settings/profile">プロフィール / 作品編集</Item> */}
+        {/* <Item to="/signin">ログアウト</Item> */}
+      </Section>
+      <Section>
+        <Tag>About</Tag>
+        <Anchor href="https://artell.life/about" target="_blank">
+          STATEMENT
+        </Anchor>
+        <Item to="/">SERVICE</Item>
+        <Anchor href="https://artell.life/" target="_blank">
+          COMPANY
+        </Anchor>
+      </Section>
+      <Section>
+        <Tag>Journal</Tag>
+        <Anchor
+          href="https://www.instagram.com/artell_gallery/"
+          target="_blank"
+        >
+          Instagram
+        </Anchor>
+        <Anchor href="https://artell.life/archives" target="_blank">
+          Archives
+        </Anchor>
+      </Section>
+      <Section>
+        <Tag>Terms</Tag>
+        <Anchor href="/terms.pdf" target="_blank">
+          利用規約
+        </Anchor>
+        <Anchor href="/privacy-policy.pdf" target="_blank">
+          プライバシーポリシー
+        </Anchor>
+        <Anchor
+          href="/specified-commercial-transaction-act.pdf"
+          target="_blank"
+        >
+          特定商取引法に基づく表記
+        </Anchor>
+        <Anchor href="https://artell.life/contact" target="_blank">
+          ご解約
+        </Anchor>
+      </Section>
+    </Container>
+  );
+};
+
+export default Menu;
+
+const Container = styled.header`
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 100vw;
+  height: 100vh;
+  background: ${color.White.hex};
+  padding-top: 12%;
+  padding-left: 68px;
+  z-index: 100;
+  ${pc(`
+    display: flex;
+    justify-content: flex-start;
+    align-items: top;
+    padding-left: 10%;
+  `)}
+`;
+
+const CloseIcon = styled(LogoCloseIcon)`
+  position: absolute;
+  top: 16px;
+  right: 24px;
+  ${pc(`
+    top: 24px;
+    right: 24px;
+  `)}
+`;
+
+const Section = styled.div`
+  margin-bottom: 32px;
+  ${pc(`
+    margin-bottom: 0px;
+    margin-right: 80px;
+  `)}
+`;
+
+const Tag = styled.div`
+  margin-bottom: 16px;
+  font-size: 14px;
+  letter-spacing: 1.2px;
+  font-weight: bold;
+  color: ${color.LightBlack.hex};
+  ${pc(`
+    margin-bottom: 24px;
+  `)}
+`;
+
+const Item = styled(Link)`
+  display: block;
+  margin-left: 24px;
+  margin-bottom: 12px;
+  text-decoration: none;
+  font-size: 12px;
+  letter-spacing: 1.2px;
+  color: ${color.LightBlack.hex};
+`;
+
+const Anchor = styled.a`
+  display: block;
+  margin-left: 24px;
+  margin-bottom: 12px;
+  text-decoration: none;
+  font-size: 12px;
+  letter-spacing: 1.2px;
+  color: ${color.LightBlack.hex};
+`;

--- a/src/components/nav-menu.svg
+++ b/src/components/nav-menu.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 18h12v-2H3v2zM3 6v2h18V6H3zm0 7h18v-2H3v2z"/></svg>


### PR DESCRIPTION
- `close.svg`, `menu.svg`の追加
- メニューをヘッダーに追加
- フッターメニューを削除（コピーライトの文言差し替え）

残TODO
- ユーザーのログイン状態チェックで、メニューアイテムの差し替え
- ユーザーネーム（アーティストネーム）の取得

<img width="1372" alt="スクリーンショット 2020-11-14 22 34 26" src="https://user-images.githubusercontent.com/33197316/99148267-15726580-26ca-11eb-8d95-553680e52233.png">
<img width="352" alt="スクリーンショット 2020-11-14 22 34 43" src="https://user-images.githubusercontent.com/33197316/99148268-16a39280-26ca-11eb-90de-95cf65bf7e13.png">

